### PR TITLE
Fix order for "Under 21" data point

### DIFF
--- a/src/main/frontend/components/main/analytics/analytics-view.html
+++ b/src/main/frontend/components/main/analytics/analytics-view.html
@@ -98,8 +98,8 @@
             if (grouping === 'age') {
               data = data.sort((a, b) => {
                 if (a.age.charAt(0) === 'U') {
-                  return -1
-                } else if (a.age.charAt(0) === 'O') {
+                  return -1;
+                } else if (b.age.charAt(0) === 'U') {
                   return 1;
                 } else {
                   return a.age.localeCompare(b.age);


### PR DESCRIPTION
Depending on initial order of data "Under 21" could end up in incorrect position

![screen shot 2017-06-26 at 13 42 29](https://user-images.githubusercontent.com/9820084/27535916-58ecbf24-5a75-11e7-8d91-b324a5994cbf.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/patient-portal-demo-flow/19)
<!-- Reviewable:end -->
