### PR TITLE
Update templates to use Polymer 2 notation

### DIFF
--- a/src/main/frontend/components/login-view.html
+++ b/src/main/frontend/components/login-view.html
@@ -80,23 +80,9 @@
     </div>
   </template>
   <script>
-    Polymer({
-      is: 'login-view',
-      properties: {
-        errorMsg: String,
-        username: {
-          type: String,
-          value: 'user'
-        },
-        password: {
-          type: String,
-          value: 'password'
-        },
-        loggedIn: {
-          type: Boolean,
-          notify: true
-        }
-      }
-    });
+    class LoginView extends Polymer.Element {
+      static get is() { return 'login-view' }
+    }
+    customElements.define(LoginView.is, LoginView);
   </script>
 </dom-module>

--- a/src/main/frontend/components/main/analytics/analytics.html
+++ b/src/main/frontend/components/main/analytics/analytics.html
@@ -49,7 +49,7 @@
         flex: 1;
       }
     </style>
-    
+
     <div class="nav">
         <a href="/analytics/age" class$="[[_isActive('age', route)]]" router-link>Age</a>
         <a href="/analytics/doctor" class$="[[_isActive('doctor', route)]]" router-link>Doctor</a>
@@ -82,10 +82,6 @@
                 type: Array,
                 value: [],
                 observer: '_categoriesSet'
-              },
-              route :{
-            	  type: String,
-            	  value: ""
               }
             }
           }
@@ -105,8 +101,8 @@
         }
 
         _isActive(link, route) {
-            return link === route ? 'active' : '';
-          }
+          return link === route ? 'active' : '';
+        }
       }
 
     customElements.define(Analytics.is, Analytics);

--- a/src/main/frontend/components/main/main-view.html
+++ b/src/main/frontend/components/main/main-view.html
@@ -72,17 +72,14 @@
 
   </template>
   <script>
-    Polymer({
-      is: 'main-view',
-      properties: {
-        page: {
-          type: String
-        }
-      },
+    class MainView extends Polymer.Element {
+      static get is() { return 'main-view' }
 
-      _isActive: function(link, page) {
+      _isActive(link, page) {
         return link === page ? 'active' : '';
       }
-    });
+
+    }
+    customElements.define(MainView.is, MainView);
   </script>
 </dom-module>

--- a/src/main/frontend/components/main/patients/journal-editor.html
+++ b/src/main/frontend/components/main/patients/journal-editor.html
@@ -111,39 +111,9 @@
     </div>
   </template>
   <script>
-    Polymer({
-      is: 'journal-editor',
-      properties: {
-        patient: {
-          type: Object,
-          notify: true,
-          observer: '_resetModel'
-        },
-        model: {
-          type: Object
-        },
-        doctors: Array,
-        appointmentTypes: {
-          type: Array,
-          value: function () {
-            return [
-              {
-                label: 'New patient',
-                value: 'NEW_PATIENT'
-              }, {
-                label: 'X-ray',
-                value: 'X_RAY'
-              }, {
-                label: 'Surgery',
-                value: 'SURGERY'
-              }, {
-                label: 'Follow up',
-                value: 'FOLLOW_UP'
-              }
-            ]
-          }
-        }
-      }
-    });
+    class JournalEditor extends Polymer.Element {
+      static get is() { return 'journal-editor' }
+    }
+    customElements.define(JournalEditor.is, JournalEditor);
   </script>
 </dom-module>

--- a/src/main/frontend/components/main/patients/patient-details.html
+++ b/src/main/frontend/components/main/patients/patient-details.html
@@ -81,15 +81,9 @@
 
   </template>
   <script>
-    Polymer({
-      is: 'patient-details',
-      properties: {
-        patient: {
-          type: Object,
-          notify: true
-        },
-        journalEntries: Array
-      }
-    })
+    class PatientDetails extends Polymer.Element {
+      static get is() { return 'patient-details' }
+    }
+    customElements.define(PatientDetails.is, PatientDetails);
   </script>
 </dom-module>

--- a/src/main/frontend/components/main/patients/patient-editor.html
+++ b/src/main/frontend/components/main/patients/patient-editor.html
@@ -126,40 +126,9 @@
     </div>
   </template>
   <script>
-    Polymer({
-      is: 'patient-editor',
-      properties: {
-        patient: {
-          type: Object,
-          notify: true,
-          observer: '_patientChanged'
-        },
-        model: Object,
-        titles: {
-          type: Array,
-          value: function () {
-            return ['Miss', 'Ms', 'Mrs', 'Mr'];
-          }
-        },
-        genders: {
-          type: Array,
-          value: function () {
-            return [{
-              label: 'Male',
-              value: 'MALE'
-            }, {
-              label: 'Female',
-              value: 'FEMALE'
-            }, {
-              label: 'Other',
-              value: 'OTHER'
-            }]
-          }
-        },
-        doctors: Array,
-        valid: Boolean
-      }
-
-    });
+    class PatientEditor extends Polymer.Element {
+      static get is() { return 'patient-editor' }
+    }
+    customElements.define(PatientEditor.is, PatientEditor);
   </script>
 </dom-module>

--- a/src/main/frontend/components/main/patients/patient-journal.html
+++ b/src/main/frontend/components/main/patients/patient-journal.html
@@ -129,21 +129,14 @@
     </vaadin-grid>
   </template>
   <script>
-    Polymer({
-      is: 'patient-journal',
-      properties: {
-        patient: {
-          type: Object,
-          notify: true
-        },
-        entries: Array
-      },
+    class PatientJournal extends Polymer.Element {
+      static get is() { return 'patient-journal' }
 
-      _expandIcon: function(expanded){
+      _expandIcon(expanded) {
         return expanded ? 'chevron-down' : 'chevron-right';
-      },
+      }
 
-      _toggleExpand: function(evt) {
+      _toggleExpand(evt) {
         const item = evt.model.item;
         if(this.$.grid.expandedItems && this.$.grid.expandedItems.includes(item)){
           this.$.grid.expandedItems = [];
@@ -151,6 +144,7 @@
           this.$.grid.expandedItems = [item];
         }
       }
-    });
+    }
+    customElements.define(PatientJournal.is, PatientJournal);
   </script>
 </dom-module>

--- a/src/main/frontend/components/main/patients/patient-profile.html
+++ b/src/main/frontend/components/main/patients/patient-profile.html
@@ -142,13 +142,9 @@
     <img class="profile-pic" src="[[patient.pictureUrl]]">
   </template>
   <script>
-    Polymer({
-      is: 'patient-profile',
-      properties: {
-        patient: {
-          type: Object
-        }
-      }
-    });
+    class PatientProfile extends Polymer.Element {
+      static get is() { return 'patient-profile' }
+    }
+    customElements.define(PatientProfile.is, PatientProfile);
   </script>
 </dom-module>

--- a/src/main/frontend/components/main/patients/patients-view.html
+++ b/src/main/frontend/components/main/patients/patients-view.html
@@ -113,30 +113,20 @@
     <slot></slot>
   </template>
   <script>
-    Polymer({
-      is: 'patients-view',
-      properties: {
-        patients: {
-          type: Array,
-          notify: true
-        },
-        currentPatient: {
-          type: Object,
-          notify: true,
-          observer: '_patientChanged'
-        },
-        narrow: Boolean
-      },
+    class PatientsView extends Polymer.Element {
+      static get is() { return 'patients-view' }
 
-      ready: function () {
-        this._updatePatients();
-      },
+      static get properties() {
+        return {
+          currentPatient: {
+            type: Object,
+            notify: true,
+            observer: '_patientChanged'
+          }
+        }
+      }
 
-      listeners: {
-        'patients-updated': '_updatePatients'
-      },
-
-      _patientChanged: function (patient) {
+      _patientChanged(patient) {
         // Grid fires an initial null selection when initialized which messes up everything
         if (!this.gridInited) {
           this.gridInited = true;
@@ -144,26 +134,21 @@
         }
 
         this._selectPatient(patient);
-      },
+      }
 
-      _updatePatients: function () {
-        this.$.patientsGrid.clearCache();
-        // TODO: re-select selected item
-      },
-
-      _selectPatient: function (patient) {
+      _selectPatient(patient) {
         this.$.patientsGrid.selectedItems = patient ? [patient] : [];
-      },
+      }
 
-      _detailsOpen: function (currentPatient) {
+      _detailsOpen(currentPatient) {
         return currentPatient ? 'open' : '';
-      },
+      }
 
-      _expandIcon: function (expanded) {
+      _expandIcon(expanded) {
         return expanded ? 'chevron-down' : 'chevron-right'
-      },
+      }
 
-      _toggleExpand: function (evt) {
+      _toggleExpand(evt) {
         const item = evt.model.item;
         if (this.$.patientsGrid.expandedItems && this.$.patientsGrid.expandedItems.includes(item)) {
           this.$.patientsGrid.expandedItems = [];
@@ -171,6 +156,7 @@
           this.$.patientsGrid.expandedItems = [item];
         }
       }
-    });
+    }
+    customElements.define(PatientsView.is, PatientsView);
   </script>
 </dom-module>


### PR DESCRIPTION
The Polymer templates are originally created for the patient-portal-demo-polymer -project and they use Polymer 1 notation. This patch updates them to use class-based notation of Polymer 2 and also removes unnecessary property-declarations.
Resolves #28.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/patient-portal-demo-flow/35)
<!-- Reviewable:end -->
