### PR TITLE
Wait for the view before assertions

### DIFF
--- a/src/test/java/com/vaadin/flow/demo/patientportal/NavigationIT.java
+++ b/src/test/java/com/vaadin/flow/demo/patientportal/NavigationIT.java
@@ -102,6 +102,6 @@ public class NavigationIT extends AbstractChromeTest {
     }
 
     private void waitLocation(String expectedLocation) {
-        waitUntil(new LocationCondition(expectedLocation));
+        waitUntil(new LocationCondition(expectedLocation), 20);
     }
 }

--- a/src/test/java/com/vaadin/flow/demo/patientportal/PatientsViewIT.java
+++ b/src/test/java/com/vaadin/flow/demo/patientportal/PatientsViewIT.java
@@ -38,6 +38,8 @@ public class PatientsViewIT extends AbstractChromeTest {
     public void testPatientData() {
         open();
 
+        waitForElementPresent(By.id("patients-view"));
+
         Assert.assertThat(
                 "Grid should contain the first name of the first patient.",
                 getCellText(13), containsString("Frederick"));


### PR DESCRIPTION
* Tests on Travis doesn't show patients table immediately after the
login page. So one needs to wait for patients view before any check
against the table.
* Timeout for location checks is increased.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/patient-portal-demo-flow/50)
<!-- Reviewable:end -->
