### PR TITLE
Disable live-reload

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,3 +16,8 @@ db.random.data=false
 db.number.patients=300
 db.number.doctors=20
 db.number.journal=20
+
+# Disable LiveReload since it doesn't affect the memory consumption a lot
+# and anyway it is used only in dev mode. Moreover, the fake iframe of
+# Devmode Gizmo affects the UIs count, and fails the tests (see #8728).
+vaadin.devmode.liveReload.enabled=false


### PR DESCRIPTION
Disables live-reload since it is used only in dev mode, does not affect the memory consumption significantly.