### PR TITLE
test: fix plugin configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -293,9 +293,10 @@
                         <configuration>
                             <maxAttempts>100</maxAttempts>
                             <wait>2500</wait>
-                            <folders>
-                                <folder>${project.build.testOutputDirectory}</folder>
-                            </folders>
+
+                            <directories>
+                                <directory>${project.build.testOutputDirectory}</directory>
+                            </directories>
                             <agents>${io.github.stephankoelle:jamm:jar}</agents>
                             <jvmArguments>
                                 -XX:+UseParallelGC


### PR DESCRIPTION
In spring-boot-maven-plugin 2.5.0 the `folders` configuration option was removed. `directories` gives the same functionality.
