### PR TITLE
test: fix date format date

### DIFF
--- a/src/test/java/com/vaadin/flow/demo/patientportal/JournalEditorIT.java
+++ b/src/test/java/com/vaadin/flow/demo/patientportal/JournalEditorIT.java
@@ -31,7 +31,7 @@ import com.vaadin.flow.component.grid.testbench.GridElement;
 
 public class JournalEditorIT extends AbstractChromeTest {
 
-    public static final String DATE = "20/10/2020";
+    public static final String DATE = "10/20/2020";
     public static final String APPOINTMENT = "X_RAY";
     public static final String DOCTOR = "Number 0, Doc ";
     public static final String ENTRY = "some notes";


### PR DESCRIPTION
'AbstractChromeTest.setDate()' expected date in 'MM/dd/yyyy' format, but the test uses a string in 'dd/MM/yyyy' format, preventing the correct date to be selected by date picker.