### PR TITLE
test: prevent login redirect for memory test

### DIFF
--- a/src/main/java/com/vaadin/flow/demo/patientportal/ui/MainView.java
+++ b/src/main/java/com/vaadin/flow/demo/patientportal/ui/MainView.java
@@ -44,8 +44,7 @@ public class MainView extends PolymerTemplate<MainView.MainViewModel>
     public void beforeEnter(BeforeEnterEvent event) {
         if (UI.getCurrent().getSession().getAttribute("login") == null
          && !(event.getLocation().getPath().endsWith("test"))) {
-            event.rerouteTo(LoginView.class);
-            UI.getCurrent().navigate(LoginView.class);
+            event.forwardTo(LoginView.class);
             return;
         }
         getModel().setPage(event.getLocation().getFirstSegment());

--- a/src/main/java/com/vaadin/flow/demo/patientportal/ui/PatientsView.java
+++ b/src/main/java/com/vaadin/flow/demo/patientportal/ui/PatientsView.java
@@ -22,8 +22,6 @@ import java.time.ZoneId;
 import java.util.Date;
 import java.util.Optional;
 
-import org.springframework.beans.factory.annotation.Autowired;
-
 import com.vaadin.demo.entities.Patient;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.UI;
@@ -38,12 +36,15 @@ import com.vaadin.flow.demo.patientportal.converters.DateToStringEncoder;
 import com.vaadin.flow.demo.patientportal.service.PatientService;
 import com.vaadin.flow.demo.patientportal.ui.patients.PatientProfile;
 import com.vaadin.flow.function.ValueProvider;
+import com.vaadin.flow.internal.AnnotationReader;
 import com.vaadin.flow.router.BeforeEnterEvent;
 import com.vaadin.flow.router.BeforeEnterObserver;
 import com.vaadin.flow.router.ParentLayout;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouterLayout;
+import com.vaadin.flow.server.auth.AnonymousAllowed;
 import com.vaadin.flow.templatemodel.TemplateModel;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * @author Vaadin Ltd
@@ -81,8 +82,8 @@ public class PatientsView extends PolymerTemplate<TemplateModel>
         ValueProvider<Patient, String> fullNameProvider = patient -> patient
                 .getLastName() + ", " + patient.getFirstName();
         grid.addColumn(LitRenderer
-                .<Patient> of("<strong>${item.fullName}</strong>")
-                .withProperty("fullName", fullNameProvider)).setHeader("Name")
+                        .<Patient>of("<strong>${item.fullName}</strong>")
+                        .withProperty("fullName", fullNameProvider)).setHeader("Name")
                 .setSortable(true).setFlexGrow(1);
 
         grid.addColumn(Patient::getId).setHeader("Id")
@@ -106,7 +107,8 @@ public class PatientsView extends PolymerTemplate<TemplateModel>
     @Override
     public void beforeEnter(BeforeEnterEvent event) {
         // todo improve the app security
-        if (UI.getCurrent().getSession().getAttribute("login") == null) {
+        boolean publicView = AnnotationReader.getAnnotationFor(event.getNavigationTarget(), AnonymousAllowed.class).isPresent();
+        if (!publicView && UI.getCurrent().getSession().getAttribute("login") == null) {
             UI.getCurrent().navigate(LoginView.class);
         }
     }

--- a/src/test/java/com/vaadin/flow/demo/patientportal/MemoryMeasurement.java
+++ b/src/test/java/com/vaadin/flow/demo/patientportal/MemoryMeasurement.java
@@ -28,7 +28,7 @@ import com.vaadin.flow.server.VaadinSession;
 public class MemoryMeasurement extends Div {
 
     public MemoryMeasurement() {
-        UI.getCurrent().getSession().setAttribute("login", "foo");
+        UI.getCurrent().getSession().setAttribute("login", true);
 
         UI.getCurrent().setId(UUID.randomUUID().toString());
         setId("session-size");

--- a/src/test/java/com/vaadin/flow/demo/patientportal/PatientsListMemory.java
+++ b/src/test/java/com/vaadin/flow/demo/patientportal/PatientsListMemory.java
@@ -22,8 +22,10 @@ import com.vaadin.flow.component.Component;
 import com.vaadin.flow.demo.patientportal.ui.MainView;
 import com.vaadin.flow.demo.patientportal.ui.PatientsView;
 import com.vaadin.flow.router.Route;
+import com.vaadin.flow.server.auth.AnonymousAllowed;
 
 @Route(value = "patients/test", layout = PatientsView.class)
+@AnonymousAllowed
 public class PatientsListMemory extends MemoryMeasurement {
 
     @Override


### PR DESCRIPTION
MemoryMeasurement sets a string value for the login session attribute that seems to cause subsequent issues with the LoginView that expect it as a boolean. For example, CI builds fail with 'String cannot be cast to Boolean' error. This change replaces the string value with a boolean.