### PR TITLE
chore: bump jna to 5.14.0 (2.7)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 
         <drivers.dir>${project.basedir}/drivers</drivers.dir>
         <drivers.downloader.phase>pre-integration-test</drivers.downloader.phase>
-        <jna.version>5.6.0</jna.version>
+        <jna.version>5.14.0</jna.version>
     </properties>
 
     <parent>


### PR DESCRIPTION
Fixes nightly build issues when running with Vaadin 14.12 and Flow 2.11