### PR TITLE
chore: bump Spring Boot to 4.0.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.3</version>
+        <version>4.0.4</version>
     </parent>
 
     <pluginRepositories>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,4 +22,4 @@ db.number.journal=20
 # Devmode Gizmo affects the UIs count, and fails the tests (see #8728).
 vaadin.devmode.liveReload.enabled=false
 
-vaadin.whitelisted-packages=com.vaadin,org.vaadin
+vaadin.allowed-packages=com.vaadin,org.vaadin


### PR DESCRIPTION
For compatibility with Jackson 3.1
