### PR TITLE
test: fix flaky patient and journal editor tests

### DIFF
--- a/src/test/java/com/vaadin/flow/demo/patientportal/AbstractChromeTest.java
+++ b/src/test/java/com/vaadin/flow/demo/patientportal/AbstractChromeTest.java
@@ -19,7 +19,6 @@ import java.util.List;
 
 import org.junit.Before;
 import org.openqa.selenium.By;
-import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
 
 import com.vaadin.flow.component.combobox.testbench.ComboBoxElement;
@@ -76,7 +75,6 @@ public abstract class AbstractChromeTest extends ChromeBrowserTest {
      */
     protected void setDate(String datePickerId, String date) {
         DatePickerElement datePicker = layout.$(DatePickerElement.class).id(datePickerId);
-        datePicker.clear();
         datePicker.setInputValue(date);
     }
 
@@ -91,9 +89,7 @@ public abstract class AbstractChromeTest extends ChromeBrowserTest {
      */
     protected void selectFromComboBox(String comboBoxId, String value) {
         ComboBoxElement comboBox = layout.$(ComboBoxElement.class).id(comboBoxId);
-        comboBox.clear();
-        comboBox.sendKeys(value);
-        comboBox.sendKeys(Keys.ENTER);
+        comboBox.selectByText(value);
     }
 
     /**

--- a/src/test/java/com/vaadin/flow/demo/patientportal/PatientEditorIT.java
+++ b/src/test/java/com/vaadin/flow/demo/patientportal/PatientEditorIT.java
@@ -36,7 +36,7 @@ public class PatientEditorIT extends AbstractChromeTest {
     public static final String FIRST_NAME = "Flow";
     public static final String MIDDLE_NAME = "Is";
     public static final String LAST_NAME = "Awesome";
-    public static final String GENDER = "female";
+    public static final String GENDER = "FEMALE";
     public static final String BIRTH_DATE = "06/13/1993";
     public static final String SSN = "453-87-1829";
     public static final String DOCTOR = "Number 1, Doc ";
@@ -80,7 +80,7 @@ public class PatientEditorIT extends AbstractChromeTest {
         assertValue("firstName", FIRST_NAME);
         assertValue("middleName", MIDDLE_NAME);
         assertValue("lastName", LAST_NAME);
-        assertValue("gender", GENDER);
+        assertValue("gender", GENDER.toLowerCase());
         assertValue("birthDate", BIRTH_DATE);
         assertValue("ssn", SSN);
         assertValue("doctor", DOCTOR.trim());


### PR DESCRIPTION
`PatientEditorIT.editPatient` and `JournalEditorIT.createJournalEntry` would intermittently time out waiting for the post-save view. The combobox and date picker helpers in `AbstractChromeTest` relied on `clear()` + `sendKeys` + `ENTER`, which races with the component's overlay/filter population — leaving the fields empty, so `Save` failed and navigation never happened.

Switch `selectFromComboBox` to `ComboBoxElement.selectByText`, and drop the redundant `clear()` in `setDate` so `setInputValue` can commit the typed value cleanly. Align the `GENDER` constant in `PatientEditorIT` with the actual combobox label (uppercase), and lowercase it for the profile assertion to match `GenderToStringEncoder` output.
