### PR TITLE
test: fix flaky birthDate handling in editor IT tests (#149) (CP: 23.x)

### DIFF
--- a/src/test/java/com/vaadin/flow/demo/patientportal/AbstractChromeTest.java
+++ b/src/test/java/com/vaadin/flow/demo/patientportal/AbstractChromeTest.java
@@ -15,7 +15,10 @@
  */
 package com.vaadin.flow.demo.patientportal;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Locale;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
@@ -67,7 +70,9 @@ public abstract class AbstractChromeTest extends ChromeBrowserTest {
      */
     protected void setDate(String datePickerId, String date) {
         DatePickerElement datePicker = layout.$(DatePickerElement.class).id(datePickerId);
-        datePicker.setInputValue(date);
+        LocalDate localDate = LocalDate.parse(date,
+                DateTimeFormatter.ofPattern("MM/dd/yyyy", Locale.ENGLISH));
+        datePicker.setDate(localDate);
     }
 
     /**


### PR DESCRIPTION
`PatientEditorIT.editPatient` intermittently kept the patient's original birthDate instead of the edited value. `AbstractChromeTest.setDate` used `DatePickerElement.setInputValue`, whose clear-then-type-then-ENTER sequence races with input focus/caret/overlay state and can leave an invalid value that the picker rejects, so the stale date gets saved.

Switch to the property-based `DatePickerElement.setDate(LocalDate)`, which sets the value with no keyboard input. The shared helper also covers `JournalEditorIT`, so both editor tests are hardened.
